### PR TITLE
989: Skipping test and better handling of not found config

### DIFF
--- a/src/RecoExplorer.py
+++ b/src/RecoExplorer.py
@@ -3,6 +3,7 @@ import sys
 import logging
 from view.RecoExplorerApp import RecoExplorerApp
 from util.file_utils import get_config_from_search, get_config_from_arg
+from exceptions.config_error import ConfigError
 
 logger = logging.getLogger(__name__)
 logging.basicConfig()
@@ -14,7 +15,7 @@ def getExplorerInstance():
 #
 # start like so: panel serve RecoExplorer.py --args config=<path_to_my_config.yaml>
 #
-if not sys.argv[1:][0]:
+if not len(sys.argv[1:]):
     exit('Unable to start Reco Explorer - no config was passed.')
 
 try:
@@ -25,5 +26,10 @@ try:
         config_full_path = get_config_from_search(pn.state.location.search, config_full_path)
 
     getExplorerInstance().server_doc()
+
+except ConfigError as e:
+    logger.critical(e.message)
+    RecoExplorerApp.render_404().server_doc()
+
 except Exception as e:
     exit(e)

--- a/src/util/file_utils.py
+++ b/src/util/file_utils.py
@@ -4,6 +4,7 @@ import glob
 import os
 import constants
 import re
+from exceptions.config_error import ConfigError
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ def get_config_from_search(search, config_full_path) -> str:
     if os.path.isfile(full_path):
         return full_path
     else:
-        raise Exception('Config file from param not found at path [' + full_path + ']')
+        raise ConfigError('Config file from search param [' + search + '] not found at path [' + full_path + ']', {})
 
 def get_client_from_path(full_path):
     match = re.search(r'/config_(\w+)\.yaml$', full_path)

--- a/src/view/RecoExplorerApp.py
+++ b/src/view/RecoExplorerApp.py
@@ -1113,6 +1113,10 @@ class RecoExplorerApp:
             logger.warning(traceback.print_exc())
         self.disablePageButtons()
 
+    @staticmethod
+    def render_404():
+        return pn.pane.Markdown(f"""## Unknown location""")
+
     #
     def render(self):
         self.assemble_components()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,6 +21,8 @@ def get_config(config) -> EnvYAML:
 
 @pytest.fixture
 def controller(start_component: list, config: str) -> RecommendationController:
+    if not config.get(constants.MODEL_CONFIG_U2C):
+        pytest.skip("configuration does not support u2c integration call")
     controller = RecommendationController(config)
     user_choice = mock_user_component(start_component)
     controller.model_type = constants.MODEL_TYPE_U2C
@@ -29,6 +31,8 @@ def controller(start_component: list, config: str) -> RecommendationController:
 
 @pytest.fixture
 def u2c_controller(start_component: list, model: list, config: str) -> RecommendationController:
+    if not config.get(constants.MODEL_CONFIG_U2C):
+        pytest.skip("configuration does not support u2c integration call")
     controller = RecommendationController(config)
     user_choice = mock_user_component(start_component)
     controller.register('user_choice', user_choice)

--- a/test/integration/test_controller_integrations.py
+++ b/test/integration/test_controller_integrations.py
@@ -4,7 +4,6 @@ import constants
 from src.controller.reco_controller import RecommendationController
 from test.test_util import mock_start_filter_component, mock_reco_filter_component, mock_start_and_reco_items_with_duplicates
 
-
 logger = logging.getLogger(__name__)
 
 @pytest.mark.parametrize("start_component, model", [(
@@ -24,7 +23,7 @@ def test_get_items_one_u2c_model_succeeds(u2c_controller: RecommendationControll
 @pytest.mark.parametrize("selection_type, start_component, model", [(
     '_by_date',
     {'validator': '_check_date', 'label': 'dateinput', 'accessor': 'get_items_by_date', 'has_paging': True},
-    ['All-Mini-LM-en', constants.MODEL_CONFIG_C2C]
+    ['T-Systems-Roberta', constants.MODEL_CONFIG_C2C]
 )])
 def test_get_items_one_c2c_model_by_date_succeeds(c2c_controller: RecommendationController) -> None:
     items = c2c_controller.get_items()
@@ -34,7 +33,7 @@ def test_get_items_one_c2c_model_by_date_succeeds(c2c_controller: Recommendation
 @pytest.mark.parametrize("selection_type, start_component, model", [(
     '_by_date',
     {'validator': '_check_date', 'label': 'dateinput', 'accessor': 'get_items_by_date', 'has_paging': True},
-    ['All-Mini-LM-en', constants.MODEL_CONFIG_C2C]
+    ['T-Systems-Roberta', constants.MODEL_CONFIG_C2C]
 )])
 def test_get_items_one_c2c_model_by_date_with_thematic_start_filter_succeeds(
         c2c_controller: RecommendationController) -> None:
@@ -56,10 +55,11 @@ def test_get_items_one_c2c_model_by_date_with_thematic_start_filter_succeeds(
             assert expected_start_theme in item.thematicCategories
 
 
+
 @pytest.mark.parametrize("selection_type, start_component, model", [(
     '_by_date',
     {'validator': '_check_date', 'label': 'dateinput', 'accessor': 'get_items_by_date', 'has_paging': True},
-    ['All-Mini-LM-en', constants.MODEL_CONFIG_C2C]
+    ['T-Systems-Roberta', constants.MODEL_CONFIG_C2C]
 )])
 def test_get_items_one_c2c_model_by_date_with_reco_sorting_succeeds(
         c2c_controller: RecommendationController) -> None:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -29,7 +29,7 @@ def mock_date_component(date_values: dict, position: str) -> object:
     date_choice.visible = True
     date_choice.name = position.capitalize() + 'datum'
     if position == 'start':
-        date_choice.value = datetime.now() + relativedelta(months=-3)
+        date_choice.value = datetime.now() + relativedelta(months=-6)
     else:
         date_choice.value = datetime.now()
     return date_choice

--- a/test/unit/dto/test_dto_methods.py
+++ b/test/unit/dto/test_dto_methods.py
@@ -9,6 +9,7 @@ from src.util.dto_utils import content_fields, dto_from_classname, dto_from_mode
 
 logger = logging.getLogger(__name__)
 
+
 def test_init_content_dto_from_classname_succeeds() -> None:
     i = dto_from_classname(
         class_name='ContentItemDto',
@@ -41,6 +42,8 @@ def test_init_content_dto_from_model_succeeds(config) -> None:
 
 
 def test_init_user_dto_from_model_succeeds(config) -> None:
+    if not config.get(constants.MODEL_CONFIG_U2C):
+        pytest.skip("configuration does not support u2c integration call")
     first_u2c_model = list(config[constants.MODEL_CONFIG_U2C][constants.MODEL_TYPE_U2C].values())[0]
     u = dto_from_model(
         model=first_u2c_model,
@@ -51,6 +54,8 @@ def test_init_user_dto_from_model_succeeds(config) -> None:
     assert u.viewer == 'UserCard@view.cards.user_card'
 
 def test_init_user_dto_in_bad_position_throws(config) -> None:
+    if not config.get(constants.MODEL_CONFIG_U2C):
+        pytest.skip("configuration does not support u2c integration call")
     first_u2c_model = list(config[constants.MODEL_CONFIG_U2C][constants.MODEL_TYPE_U2C].values())[0]
     with pytest.raises(TypeError):
         dto_from_model(


### PR DESCRIPTION
- u2c tests are now skipped, if no u2c config
- simple not found template now rendered when url is false 