### PR TITLE
1012: Add ModelType param to pa service

### DIFF
--- a/src/controller/reco_controller.py
+++ b/src/controller/reco_controller.py
@@ -80,7 +80,8 @@ class RecommendationController():
         return self.item_accessor.get_unique_vals_for_column(column=component_name, sort=True)
 
     def get_user_cluster(self):
-        self.user_cluster_accessor.set_endpoint(self.config[constants.MODEL_CONFIG_U2C]['clustering_models']['U2C-Knn-Model']['endpoint'])
+        # TODO: improve the model config pass
+        self.user_cluster_accessor.set_model_config(self.config[constants.MODEL_CONFIG_U2C]['clustering_models']['U2C-Knn-Model'])
         self.user_cluster = self.user_cluster_accessor.get_user_cluster()
         return list(self.user_cluster.keys())
 
@@ -145,7 +146,7 @@ class RecommendationController():
         module = importlib.import_module(handler_dir)
         class_ = getattr(module, handler_name)
         self.reco_accessor = class_(self.config)
-        self.reco_accessor.set_endpoint(model_info['endpoint'])
+        self.reco_accessor.set_model_config(model_info)
         return True
 
     def get_model_params(self):
@@ -265,7 +266,8 @@ class RecommendationController():
             raise Exception("Unknown user selection widget [" + active_components[0].params.label + ']')
 
     def _get_start_users_by_genre(self, user_dto: UserItemDto, genre_widget, start_idx, end_idx) -> tuple[int, list[UserItemDto]]:
-        self.user_cluster_accessor.set_endpoint(self.config[constants.MODEL_CONFIG_U2C]['clustering_models']['U2C-Knn-Model']['endpoint'])
+        # TODO: improve the model config pass
+        self.user_cluster_accessor.set_model_config(self.config[constants.MODEL_CONFIG_U2C]['clustering_models']['U2C-Knn-Model'])
         field_map = self.config[constants.MODEL_CONFIG_U2C]['clustering_models']['U2C-Knn-Model']['field_mapping']
         response = self.user_cluster_accessor.get_users_by_category(genre_widget.value)
         num_users = len(response[genre_widget.value])

--- a/src/model/nn_seeker.py
+++ b/src/model/nn_seeker.py
@@ -15,5 +15,5 @@ class NnSeeker(ABC):
         pass
 
     @abstractmethod
-    def set_endpoint( self, endpoint ):
+    def set_model_config(self, model_config ):
         pass

--- a/src/model/opensearch/base_data_accessor_opensearch.py
+++ b/src/model/opensearch/base_data_accessor_opensearch.py
@@ -140,7 +140,6 @@ class BaseDataAccessorOpenSearch(BaseDataAccessor):
         oldest_item_in_base_ts = pd.Timestamp(min_date).timestamp()
         return newest_item_in_base_ts, oldest_item_in_base_ts
 
-
     def get_top_k_vals_for_column( self, column, k) -> list:
         
         #apply field mapping if defined

--- a/src/model/opensearch/nn_seeker_opensearch.py
+++ b/src/model/opensearch/nn_seeker_opensearch.py
@@ -30,8 +30,8 @@ class NnSeekerOpenSearch(NnSeeker):
         
         self.embedding_field_name = 'embedding_01'
 
-    def set_endpoint( self, endpoint ):
-        self._set_model_name(endpoint.removeprefix("opensearch://"))
+    def set_model_config( self, model_config ):
+        self._set_model_name(model_config['endpoint'].removeprefix("opensearch://"))
 
     def _set_model_name( self, model_name ):
         self.embedding_field_name = model_name

--- a/src/model/opensearch/nn_seeker_opensearch.py
+++ b/src/model/opensearch/nn_seeker_opensearch.py
@@ -49,7 +49,6 @@ class NnSeekerOpenSearch(NnSeeker):
     def set_max_num_neighbours(self, num_neighbours):
         self.__max_num_neighbours = num_neighbours
     
-    
     def __get_nn_by_embedding(self, embedding, k, filter_criteria):
         return self.__get_exact__nn_by_embedding(embedding, k, filter_criteria)
 
@@ -104,7 +103,6 @@ class NnSeekerOpenSearch(NnSeeker):
 
         return query
 
-    
     def __get_approx_nn_by_embedding(self, embedding, k, filter_criteria):
 
         query = {
@@ -138,7 +136,6 @@ class NnSeekerOpenSearch(NnSeeker):
 
         return ids,nn_dists
 
-        
     def __get_vec_for_content_id(self, content_id ):
         query = {
           "size": 1,

--- a/src/model/rest/nn_seeker_paservice.py
+++ b/src/model/rest/nn_seeker_paservice.py
@@ -17,9 +17,10 @@ class NnSeekerPaService(NnSeekerRest):
         self.__configuration_c2c = "relatedItems"
         self.__configuration_u2c = "forYou"
         self.__explain = False
+        self.__model_config = {}
+
         # TODO: this can probably be removed when primary key handling is depricated after ingest micro service deployment
         self.__config = config
-        self.__model_config = {}
         super().__init__()
 
     def get_k_NN(self, item: ItemDto, k, nn_filter) -> tuple[list, list, str]:
@@ -66,7 +67,8 @@ class NnSeekerPaService(NnSeekerRest):
             "userId": user_id
         }
 
-        params["modelType"] = model_props["param_model_type"] if model_props["param_model_type"] else ''
+        if model_props["param_model_type"]:
+            params["modelType"] = model_props["param_model_type"]
 
         status, pa_recos = super().post_2_endpoint(self.__model_config['endpoint'], headers, params)
 

--- a/src/model/rest/nn_seeker_rest.py
+++ b/src/model/rest/nn_seeker_rest.py
@@ -21,7 +21,6 @@ class NnSeekerRest(NnSeeker):
             redirect=self.__retry_redirects,
             backoff_factor=self.__backoff_factor
         )
-
         http = PoolManager(retries=retries)
 
         logger.info('calling [' + base_uri + '] with params ' + json.dumps(post_params))
@@ -29,4 +28,5 @@ class NnSeekerRest(NnSeeker):
         response = http.request('POST', base_uri, fields=post_params, headers=headers)
         status_code = response.status
         data = json.loads(response.data.decode('utf-8'))
+
         return status_code, data

--- a/src/model/sagemaker/clustering_model_client.py
+++ b/src/model/sagemaker/clustering_model_client.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 class ClusteringModelClient:
 
     def __init__( self, config ):
-        self.__endpoint = ''
+        self.__model_config = {}
         cross_account_options = self.__get_cross_account_options(
             config[constants.MODEL_CONFIG_U2C]['clustering_models']['U2C-Knn-Model']['role_arn']
         )
@@ -21,15 +21,15 @@ class ClusteringModelClient:
         json_body = json.dumps({ "action": "list_clusters" })
 
         try:
-            logger.info('Invoking clustering endpoint call to [' + self.__endpoint + ']')
+            logger.info('Invoking clustering endpoint call to [' + self.__model_config['endpoint'] + ']')
             response = self._client.invoke_endpoint(
-                EndpointName=self.__endpoint.removeprefix("sagemaker://"),
+                EndpointName=self.__model_config['endpoint'].removeprefix("sagemaker://"),
                 Body=json_body,
                 ContentType="application/json",
             )
         except Exception as e:
             logging.error(e)
-            raise EndpointError("Couldn't get a response from endpoint [" + self.__endpoint + ']')
+            raise EndpointError("Couldn't get a response from endpoint [" + self.__model_config['endpoint'] + ']')
 
         response_data = json.loads(response["Body"].read().decode("utf-8"))
         user_cluster = {}
@@ -51,15 +51,15 @@ class ClusteringModelClient:
         json_body = json.dumps(body_dict)
 
         try:
-            logger.info('Invoking clustering endpoint call to [' + self.__endpoint + ']')
+            logger.info('Invoking clustering endpoint call to [' + self.__model_config['endpoint'] + ']')
             response = self._client.invoke_endpoint(
-                EndpointName=self.__endpoint.removeprefix("sagemaker://"),
+                EndpointName=self.__model_config['endpoint'].removeprefix("sagemaker://"),
                 Body=json_body,
                 ContentType="application/json",
             )
         except Exception as e:
             logging.error(e)
-            raise EndpointError("Couldn't get a response from endpoint [" + self.__endpoint + ']', {})
+            raise EndpointError("Couldn't get a response from endpoint [" + self.__model_config['endpoint'] + ']', {})
 
         response_data = json.loads(response["Body"].read().decode("utf-8"))
         if not len(response_data):
@@ -68,8 +68,8 @@ class ClusteringModelClient:
         user_cluster[genreCategory] = response_data
         return user_cluster
 
-    def set_endpoint(self, endpoint):
-        self.__endpoint = endpoint
+    def set_model_config(self, model_config):
+        self.__model_config = model_config
 
     def __get_cross_account_options(self, role_arn):
         sts_client = boto3client("sts")

--- a/src/model/u2c_seeker.py
+++ b/src/model/u2c_seeker.py
@@ -7,9 +7,9 @@ class U2CSeeker(ABC):
         pass
 
     @abstractmethod
-    def set_endpoint( self, endpoint ):
+    def get_model_params(self):
         pass
 
     @abstractmethod
-    def get_model_params(self):
+    def set_model_config( self, model_config ):
         pass


### PR DESCRIPTION
- refactor `set_endpoint` to `set_model_config` on `NnSeeker` and `U2CSeeker` classes for better handling of model configurations
- add `modelType` param to PA service requests which can now be used to differentiate between models 