### PR TITLE
SNTWREC-28: Tests Redesign

### DIFF
--- a/test/unit/controller/test_controller_methods.py
+++ b/test/unit/controller/test_controller_methods.py
@@ -1,16 +1,37 @@
+from collections import namedtuple
 import pytest
+from src import constants
 from src.controller.reco_controller import RecommendationController
 
+
 @pytest.fixture
+def controller() -> RecommendationController:
+    controller = RecommendationController(
+        config={
+            "opensearch.user": "test",
+            "opensearch.pass": "test",
+            "opensearch.host": "test",
+            "opensearch.port": "8080",
+            "opensearch.index": "test",
+            "opensearch.field_mapping": {},
+        }
+    )
+    controller.model_type = constants.MODEL_TYPE_C2C
+    MockComponent = namedtuple("component", ["visible"])
+    controller.components.update(
+        {
+            "item_choice": {"test": MockComponent(True)},
+        }
+    )
+    return controller
+
+
 def test_increasing_page_number_succeeds(controller: RecommendationController) -> None:
     controller.increase_page_number()
     assert controller.get_page_number() == 2
 
-@pytest.mark.parametrize("start_component", [
-    (True, 'genre_users',  '_check_category', 'Comedy'),
-])
+
 def test_get_start_components_succeeds(controller: RecommendationController) -> None:
     component = controller._get_active_start_components()
     assert isinstance(component, list)
     assert component
-

--- a/test/unit/dto/test_dto_methods.py
+++ b/test/unit/dto/test_dto_methods.py
@@ -1,7 +1,8 @@
 import copy
 import logging
+from typing import cast
 import pytest
-import constants
+import src.constants as constants
 from src.dto.content_item import ContentItemDto
 from src.dto.user_item import UserItemDto
 from dataclasses import dataclass, fields
@@ -10,81 +11,110 @@ from src.util.dto_utils import content_fields, dto_from_classname, dto_from_mode
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture
+def config() -> dict:
+    return {
+        constants.MODEL_CONFIG_C2C: {
+            constants.MODEL_TYPE_C2C: {
+                "test-model": {
+                    "content_type": "ContentItemDto",
+                }
+            }
+        },
+        constants.MODEL_CONFIG_U2C: {
+            constants.MODEL_TYPE_U2C: {
+                "test-model": {
+                    "user_type": "UserItemDto",
+                }
+            }
+        },
+    }
+
+
 def test_init_content_dto_from_classname_succeeds() -> None:
     i = dto_from_classname(
-        class_name='ContentItemDto',
+        class_name="ContentItemDto",
         position=constants.ITEM_POSITION_START,
         item_type=constants.ITEM_TYPE_CONTENT,
-        provenance=constants.ITEM_PROVENANCE_C2C
+        provenance=constants.ITEM_PROVENANCE_C2C,
     )
-    assert i.viewer == 'ContentStartCard@view.cards.content_start_card'
+    assert i.viewer == "ContentStartCard@view.cards.content_start_card"
+
 
 def test_init_history_dto_from_classname_succeeds() -> None:
     i = dto_from_classname(
-        class_name='HistoryItemDto',
+        class_name="HistoryItemDto",
         position=constants.ITEM_POSITION_START,
         item_type=constants.ITEM_TYPE_CONTENT,
-        provenance=constants.ITEM_PROVENANCE_C2C
+        provenance=constants.ITEM_PROVENANCE_C2C,
     )
-    assert i.viewer == 'ContentHistoryCard@view.cards.floatpanel_history_card'
+    assert i.viewer == "ContentHistoryCard@view.cards.floatpanel_history_card"
+
 
 def test_init_content_dto_from_model_succeeds(config) -> None:
-    first_c2c_model = list(config[constants.MODEL_CONFIG_C2C][constants.MODEL_TYPE_C2C].values())[0]
+    first_c2c_model = list(
+        config[constants.MODEL_CONFIG_C2C][constants.MODEL_TYPE_C2C].values()
+    )[0]
     i = dto_from_model(
         model=first_c2c_model,
         position=constants.ITEM_POSITION_START,
         item_type=constants.ITEM_TYPE_CONTENT,
-        provenance=constants.ITEM_PROVENANCE_C2C
+        provenance=constants.ITEM_PROVENANCE_C2C,
     )
-    assert i.viewer == 'ContentStartCard@view.cards.content_start_card'
-    i.provenance = 'mediathek'
-    assert i.provenance == 'mediathek'
+    assert i.viewer == "ContentStartCard@view.cards.content_start_card"
+    i.provenance = "mediathek"
+    assert i.provenance == "mediathek"
 
 
 def test_init_user_dto_from_model_succeeds(config) -> None:
-    if not config.get(constants.MODEL_CONFIG_U2C):
-        pytest.skip("configuration does not support u2c integration call")
-    first_u2c_model = list(config[constants.MODEL_CONFIG_U2C][constants.MODEL_TYPE_U2C].values())[0]
+    first_u2c_model = list(
+        config[constants.MODEL_CONFIG_U2C][constants.MODEL_TYPE_U2C].values()
+    )[0]
     u = dto_from_model(
         model=first_u2c_model,
         position=constants.ITEM_POSITION_START,
         item_type=constants.ITEM_TYPE_USER,
-        provenance=constants.ITEM_PROVENANCE_U2C
+        provenance=constants.ITEM_PROVENANCE_U2C,
     )
-    assert u.viewer == 'UserCard@view.cards.user_card'
+    assert u.viewer == "UserCard@view.cards.user_card"
+
 
 def test_init_user_dto_in_bad_position_throws(config) -> None:
-    if not config.get(constants.MODEL_CONFIG_U2C):
-        pytest.skip("configuration does not support u2c integration call")
-    first_u2c_model = list(config[constants.MODEL_CONFIG_U2C][constants.MODEL_TYPE_U2C].values())[0]
+    first_u2c_model = list(
+        config[constants.MODEL_CONFIG_U2C][constants.MODEL_TYPE_U2C].values()
+    )[0]
     with pytest.raises(TypeError):
         dto_from_model(
             model=first_u2c_model,
             position=constants.ITEM_POSITION_RECO,
             item_type=constants.ITEM_TYPE_USER,
-            provenance=constants.ITEM_PROVENANCE_U2C
+            provenance=constants.ITEM_PROVENANCE_U2C,
         )
 
-def test_init_and_copy_content_dto_succeeds(config) -> None:
-    i = dto_from_classname(
-        class_name='ContentItemDto',
-        position=constants.ITEM_POSITION_START,
-        item_type=constants.ITEM_TYPE_CONTENT,
-        provenance=constants.ITEM_PROVENANCE_C2C
+
+def test_init_and_copy_content_dto_succeeds() -> None:
+    i = cast(
+        ContentItemDto,
+        dto_from_classname(
+            class_name="ContentItemDto",
+            position=constants.ITEM_POSITION_START,
+            item_type=constants.ITEM_TYPE_CONTENT,
+            provenance=constants.ITEM_PROVENANCE_C2C,
+        ),
     )
-    assert i.viewer == 'ContentStartCard@view.cards.content_start_card'
+    assert i.viewer == "ContentStartCard@view.cards.content_start_card"
     j = copy.copy(i)
-    j.genreCategory = 'Ard Retro'
+    j.genreCategory = "Ard Retro"
     assert j.genreCategory != i.genreCategory
 
-def test_dto_fields_list_succeeds(config) -> None:
+
+def test_dto_fields_list_succeeds() -> None:
     i = dto_from_classname(
-        class_name='ContentItemDto',
+        class_name="ContentItemDto",
         position=constants.ITEM_POSITION_START,
         item_type=constants.ITEM_TYPE_CONTENT,
-        provenance=constants.ITEM_PROVENANCE_C2C
+        provenance=constants.ITEM_PROVENANCE_C2C,
     )
-    all_item_props = { f.name for f in fields(i) if f.init }
+    all_item_props = {f.name for f in fields(i) if f.init}
     content_only_props = content_fields(i)
     assert content_only_props < all_item_props
-


### PR DESCRIPTION
With this redesign, I overwrote the global fixtures with appropriate dummies in the specific unit test modules.

`pytest test/unit` can now be run without any config.