### PR TITLE
SNTWREC-171 add accordion cards widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,6 @@ In this example the second multi select Widget is hidden on load. When the User 
 | type    | yes       | -                          | widget type definition: **accordion**                                                                                                                                                                                                                                                  |
 | label   | no        | Default Accordion Headline | headline of the accordion widget                                                                                                                                                                                                                                                       |
 | active  | no        | []                         | When there are multiple widgets in the accordion this defines which accordion content widget should be open when the application is started (0 -> first). Each widget which should be open must be in the list, when the list is empty (fallback) no accordion content widget is open. |
-| toggle  | no        | False                      | Option Flag which defines if more than one accordion content type can be opened if there are multiple ones. If True and first accordion content is opened and user opens the second accordion content, the first one gets closed automatically.                                        |
 | content | yes       | -                          | This defines the content of the accordion. There can be multiple entries of other widgets here which need to be exactly configured like they would, when standing alone. Available widget options are: TextWidget, MultiSelectWidget, DateTimePickerWidget, RadioBoxWidget             |
 
 ### Example of a Accordion Widget Configuration
@@ -449,6 +448,29 @@ In this example the second multi select Widget is hidden on load. When the User 
 		    -	type: 'text_field'
 			    ...
 This configuration would create a Accordion Widget with a label and two contents inside, a Multi Select Widget and a Text Field Widget. The Multi Select Widget will be initially visible and wont close when the text field is selected.  Be aware that the widgets inside the content are treated as standard widgets so they have all the features and requirements as if you would confige it outside the Accordion.
+
+## Accordion Cards Widget
+
+###  Accordion Cards Config Overview
+
+| keyword | mandatory | fallback value | description                                                                                                                                                                                                                                                                                   |
+|---------|-----------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| type    | yes       | -              | widget type definition: **accordion_with_cards**                                                                                                                                                                                                                                              |
+| active  | no        | [0]            | When there are multiple widgets in the accordion this defines which accordion content widget should be open when the application is started (0 -> first). Each widget which should be open must be in the list, when the list is empty (fallback) the first accordion content widget is open. |
+| toggle  | no        | False          | Option Flag which defines if more than one accordion content type can be opened if there are multiple ones. If True and first accordion content is opened and user opens the second accordion content, the first one gets closed automatically.                                               |
+| content | yes       | -              | This defines the cards of the accordion. There can be multiple entries of other accordion widgets here which need to be exactly configured like they would, when standing alone.                                                                                                              |
+
+### Example of an Accordion Cards Widget Configuration
+
+    -   type: 'accordion_with_cards'
+	    active: 0
+	    toggle: True
+	    content:
+		    -	type: 'accordion'
+			    ...
+		    -	type: 'accordion'
+			    ...
+This Widget Configuration is just a Pool if you want to create multiple accordion widgets which can interact with each other (Toggle). So you can just use this if you want to display multiple accordion cards
 
 ## Radio Box Widget
 

--- a/config/schema/ui_schema.json
+++ b/config/schema/ui_schema.json
@@ -347,10 +347,6 @@
           "type": "integer",
           "description": "which accordion should be open by default."
         },
-        "toggle": {
-          "type": "boolean",
-          "description": "If true, multiple accordions can be opened at the same time."
-        },
         "content": {
           "type": "array",
           "description": "Array of objects which can be shown in the accordion.",
@@ -373,6 +369,38 @@
               },
               {
                 "$ref": "#/$defs/slider"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "type",
+        "content"
+      ]
+    },
+    "accordion_with_cards": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "accordion_with_cards"
+        },
+        "active": {
+          "type": "integer",
+          "description": "which accordion card should be open by default."
+        },
+        "toggle": {
+          "type": "boolean",
+          "description": "If false, multiple accordions can be opened at the same time."
+        },
+        "content": {
+          "type": "array",
+          "description": "Array of accordion cards.",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/accordion"
               }
             ]
           }

--- a/src/view/RecoExplorerApp.py
+++ b/src/view/RecoExplorerApp.py
@@ -23,6 +23,7 @@ from view.widgets.reset_button import ResetButtonWidget
 from view.widgets.slider_widget import SliderWidget
 from view.widgets.text_area_input_widget import TextAreaInputWidget
 from view.widgets.text_field_widget import TextFieldWidget
+from view.widgets.accordion_widget import AccordionWidgetWithCards
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -32,7 +33,6 @@ logger.setLevel(logging.INFO)
 # Main App
 #
 class RecoExplorerApp:
-
     def __init__(self, config_full_path: str, config: dict[str, str]) -> None:
         # basic setup
         self.config = config
@@ -51,6 +51,9 @@ class RecoExplorerApp:
             ui_constants.ACCORDION_TYPE_VALUE: AccordionWidget(self, self.controller),
             ui_constants.SLIDER_TYPE_VALUE: SliderWidget(self, self.controller),
             ui_constants.TEXT_AREA_INPUT_TYPE_VALUE: TextAreaInputWidget(
+                self, self.controller
+            ),
+            ui_constants.ACCORDION_WITH_CARDS_TYPE_VALUE: AccordionWidgetWithCards(
                 self, self.controller
             ),
         }
@@ -422,20 +425,26 @@ class RecoExplorerApp:
     # Filtering block u2c
     def define_reco_filtering_selection_u2c(self):
         self.editorial_choice = pn.widgets.MultiSelect(
-            name="Empfehlungen auf Kategorie einschränken", options=[], visible=True, size=4
+            name="Empfehlungen auf Kategorie einschränken",
+            options=[],
+            visible=True,
+            size=4,
         )
 
         self.editorial_choice.params = {
             "label": "editorialCategories",
             "validator": "_check_editorial_category",
-            "reset_to": []
+            "reset_to": [],
         }
 
         self.editorial_choice.options = list(
-            filter(lambda item: item != "n/a", self.controller.get_item_defaults("editorialCategories"))
+            filter(
+                lambda item: item != "n/a",
+                self.controller.get_item_defaults("editorialCategories"),
+            )
         )
 
-        user_editorial_watcher =  self.editorial_choice.param.watch(
+        user_editorial_watcher = self.editorial_choice.param.watch(
             self.trigger_reco_filter_choice, "value", onlychanged=True
         )
 
@@ -443,7 +452,7 @@ class RecoExplorerApp:
             "reco_filter_u2c",
             self.editorial_choice,
             user_editorial_watcher,
-            self.trigger_reco_filter_choice
+            self.trigger_reco_filter_choice,
         )
 
         # reset button
@@ -1447,10 +1456,8 @@ class RecoExplorerApp:
             self.item_source.max_width = accordion_max_width
 
             # User source
-            self.user_source = pn.Accordion(
-                ("User-Filter", self.user_filter_choice)
-            )
-#            self.user_source.active = [1,1]
+            self.user_source = pn.Accordion(("User-Filter", self.user_filter_choice))
+            #            self.user_source.active = [1,1]
             self.user_source.toggle = False
             self.user_source.max_width = accordion_max_width
             self.user_source.param.watch(
@@ -1481,7 +1488,7 @@ class RecoExplorerApp:
                 ("Genre-Filter", self.genre_col),
                 ("Subgenre-Filter", self.subgenre_col),
                 ("Themen-Filter", self.theme_col),
-                ("Sendereihe-Filter", self.show_col)
+                ("Sendereihe-Filter", self.show_col),
             )
             self.reco_items.max_width = accordion_max_width
 

--- a/src/view/ui_constants.py
+++ b/src/view/ui_constants.py
@@ -45,11 +45,14 @@ RESET_IDENTIFIER_UPPER_ITEM_FILTER = "upper_item_filter"
 RESET_IDENTIFIER_RECO_FILTER = "reco_filter"
 RESET_IDENTIFIER_UPPER_RECO_FILTER = "upper_reco_filter"
 
+# Accordion Cards
+ACCORDION_CARD_TOGGLE_KEY = "toggle"
+ACCORDION_CARD_ACTIVE_KEY = "active"
+
 # Accordion
 ACCORDION_CONTENT_KEY = "content"
 ACCORDION_LABEL_KEY = "label"
 ACCORDION_ACTIVE_KEY = "active"
-ACCORDION_TOGGLE_KEY = "toggle"
 ACCORDION_RESET_BUTTON_KEY = "accordion-reset-button"
 ACCORDION_MAX_WIDTH = 323
 
@@ -105,6 +108,7 @@ DATE_TIME_PICKER_TYPE_VALUE = "date_time_picker"
 RADIO_BOX_TYPE_VALUE = "radio_box"
 TEXT_AREA_INPUT_TYPE_VALUE = "text_area_input"
 ACCORDION_RESET_BUTTON_TYPE_VALUE = "accordion-reset-button"
+ACCORDION_WITH_CARDS_TYPE_VALUE = "accordion_with_cards"
 
 
 # Fallbacks (if no key and value was given in the config yaml)


### PR DESCRIPTION
Accordion Cards can now be configured like this: 
`                 

                  type: accordion_with_cards
                  toggle: True
                  active: 1
                  content:
                      - type: accordion
                        label: Test Accordion 1
                        active: 1
                        content:
                          - type: multi_select
                            label: A Multi Select
                            tooltip: Muli Select Tooltip
                            options:
                                - display_name: Option A
                                - display_name: Option B
                      -   type: accordion
                          label: Test Accordion 2
                          active: 1
                          content:
                              -   type: multi_select
                                  label: A Multi Select
                                  tooltip: Muli Select Tooltip
                                  options:
                                      -   display_name: Option C
                                      -   display_name: Option D`