### PR TITLE
SNTWREC-164: Maintenance Task für Embedding Service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -84,6 +84,7 @@ services:
       - OPENSEARCH_INDEX=test_index
       - MAPPING_DEFINITION='{"id":.sophoraId,"externalid":.externalId,"uuid":.uuid,"type":.type,"title":.title,"description":.["description"],"longDescription":.["longDescription"],"embedText":(.title+""+.longDescription),"availableFrom":.availableFrom,"availableTo":.availableTo,"firstPublicationDate":.firstPublicationDate,"keywords":.keywords,"language":.language,"duration":.durationSeconds,"thematicCategories":.thematicCategories,"genreCategory":.genreCategory,"subgenreCategories":.subgenreCategories,"filterCategory":.filterCategory,"structurePath":.structurePath,"site":.site,"domain":.domain,"teaserimage":.teaserImage.url,"fskAgeRating":.fskAgeRating,"contentRatings":.contentRatings,"geoAvailability":.geoAvailability,"all-MiniLM-L6-v2_title_desc_nokeywords":.["all-MiniLM-L6-v2_title_desc_nokeywords"],"sophoraid":.sophoraId}'
       - STORAGE_SERVICE_ACCOUNT
+      - REEMBED_INTERVAL_SECONDS=60
     networks:
       - opensearch-net
   search-service:

--- a/microservices/embeddingservice/dto/embed_data.py
+++ b/microservices/embeddingservice/dto/embed_data.py
@@ -9,4 +9,4 @@ class EmbeddingRequest(BaseModel):
 class AddEmbeddingToDocRequest(BaseModel):
     id: str
     embedText: str
-
+    models: list[str] | None = None

--- a/microservices/embeddingservice/src/embed_text.py
+++ b/microservices/embeddingservice/src/embed_text.py
@@ -98,7 +98,7 @@ class EmbedText:
         embedding["id"] = id
         # Send request to search service to add embedding to index
         httpx.post(
-            url=f"{self.config.get('base_url_search')}/create-single-document",
+            url=f"{self.config.get('base_url_search')}/documents/{id}",
             json=embedding,
             headers={"x-api-key": self.config["api_key"]},
         )

--- a/microservices/embeddingservice/src/main.py
+++ b/microservices/embeddingservice/src/main.py
@@ -37,5 +37,10 @@ def add_embedding_to_document(data: AddEmbeddingToDocRequest):
     return result
 
 
+@router.get("/models")
+def get_models():
+    return list(text_embedder.models.keys())
+
+
 app = FastAPI(title="Embedding Service")
 app.include_router(router, prefix=ROUTER_PREFIX)

--- a/microservices/embeddingservice/src/main.py
+++ b/microservices/embeddingservice/src/main.py
@@ -32,7 +32,7 @@ def get_embedding(data: EmbeddingRequest):
 
 @router.post("/add-embedding-to-doc")
 def add_embedding_to_document(data: AddEmbeddingToDocRequest):
-    result = text_embedder.embed_text(data.embedText, [])
+    result = text_embedder.embed_text(data.embedText, data.models)
     text_embedder.add_embedding_to_document(data.id, result)
     return result
 
@@ -43,4 +43,5 @@ def get_models():
 
 
 app = FastAPI(title="Embedding Service")
+
 app.include_router(router, prefix=ROUTER_PREFIX)

--- a/microservices/embeddingservice/tests/test_api.py
+++ b/microservices/embeddingservice/tests/test_api.py
@@ -23,10 +23,9 @@ def test_embedding__malformed_request(test_client: TestClient):
     assert response.json() == {
         "detail": [
             {
-                "input": {"malformed": "request"},
                 "loc": ["body", "embedText"],
-                "msg": "Field required",
-                "type": "missing",
+                "msg": "field required",
+                "type": "value_error.missing",
             }
         ]
     }
@@ -140,23 +139,21 @@ def test_add_embedding_to_document__malformed_request(test_client: TestClient):
     assert response.json() == {
         "detail": [
             {
-                "input": {"malformed": "request"},
                 "loc": ["body", "id"],
-                "msg": "Field required",
-                "type": "missing",
+                "msg": "field required",
+                "type": "value_error.missing",
             },
             {
-                "input": {"malformed": "request"},
                 "loc": ["body", "embedText"],
-                "msg": "Field required",
-                "type": "missing",
+                "msg": "field required",
+                "type": "value_error.missing",
             },
         ]
     }
 
 
 def test_add_embedding_to_document(httpx_mock, test_client: TestClient):
-    httpx_mock.add_response("https://test.io/search/create-single-document", json={})
+    httpx_mock.add_response("https://test.io/search/documents/test", json={})
 
     response = test_client.post(
         "/add-embedding-to-doc", json={"id": "test", "embedText": "This is a test."}
@@ -191,6 +188,6 @@ def test_add_embedding_to_document(httpx_mock, test_client: TestClient):
     requests = httpx_mock.get_requests()
     assert len(requests) == 1
     assert requests[0].method == "POST"
-    assert requests[0].url == "https://test.io/search/create-single-document"
+    assert requests[0].url == "https://test.io/search/documents/test"
     assert requests[0].headers["x-api-key"] == "test_key"
     assert requests[0].content == json.dumps(response_json).encode()

--- a/microservices/embeddingservice/tests/test_api.py
+++ b/microservices/embeddingservice/tests/test_api.py
@@ -191,3 +191,12 @@ def test_add_embedding_to_document(httpx_mock, test_client: TestClient):
     assert requests[0].url == "https://test.io/search/documents/test"
     assert requests[0].headers["x-api-key"] == "test_key"
     assert requests[0].content == json.dumps(response_json).encode()
+
+
+def test_get_models(test_client: TestClient):
+    response = test_client.get("/models")
+    assert response.status_code == 200
+    assert response.json() == [
+        "all-MiniLM-L6-v2",
+        "distiluse-base-multilingual-cased-v1",
+    ]

--- a/microservices/ingestservice/requirements.txt
+++ b/microservices/ingestservice/requirements.txt
@@ -5,6 +5,7 @@ httpx==0.27.2
 opensearch-py==2.7.1
 pyjq==2.6.0
 pytest==8.3.3
+pytest-asyncio
 pytest-httpx==0.30.0
 pytest-mock==3.14.0
 python-dotenv==1.0.1

--- a/microservices/ingestservice/src/clients.py
+++ b/microservices/ingestservice/src/clients.py
@@ -42,6 +42,11 @@ class SearchServiceClient:
         _raise_for_status(response)
         return response.json()["hits"]["hits"][0]["_source"]
 
+    def query(self, query: dict):
+        response = self.client.post("/query", json=query)
+        _raise_for_status(response)
+        return response.json()
+
 
 def _raise_for_status(response: httpx.Response):
     try:

--- a/microservices/ingestservice/src/clients.py
+++ b/microservices/ingestservice/src/clients.py
@@ -19,25 +19,24 @@ class SearchServiceClient:
 
     def delete(self, id: str):
         response = self.client.delete(
-            "/delete-data",
-            params={"document_id": id},
+            f"/documents/{id}",
         )
         _raise_for_status(response)
         return response.json()
 
-    def create_single_document(self, document: dict):
-        response = self.client.post("/create-single-document", json=document)
+    def create_single_document(self, id: str, document: dict):
+        response = self.client.post(f"/documents/{id}", json=document)
         _raise_for_status(response)
         return response.json()
 
     def create_multiple_documents(self, documents: dict[str, Any]):
-        response = self.client.post("/create-multiple-documents", json=documents)
+        response = self.client.post("/documents", json=documents)
         _raise_for_status(response)
         return response
 
     def get(self, id: str, fields: list[str] | None = None):
         response = self.client.get(
-            f"/document/{id}",
+            f"/documents/{id}",
             params={"fields": ",".join(fields) if fields else None},
         )
         _raise_for_status(response)

--- a/microservices/ingestservice/src/main.py
+++ b/microservices/ingestservice/src/main.py
@@ -152,5 +152,5 @@ def get_tasks() -> TasksResponse:
     return TasksResponse(tasks=tasks.values())
 
 
-app = FastAPI(title="Ingest Service")
+app = FastAPI(title="Ingest Service", lifespan=lifespan)
 app.include_router(router, prefix=ROUTER_PREFIX)

--- a/microservices/ingestservice/src/main.py
+++ b/microservices/ingestservice/src/main.py
@@ -13,7 +13,7 @@ from google.cloud import storage
 from pydantic import ValidationError
 from src.bulk import bulk_ingest
 from src.clients import SearchServiceClient
-from src.maintenance import task_cleaner, reembedding_background_task
+from src.maintenance import reembedding_background_task, task_cleaner
 from src.models import (
     FullLoadRequest,
     FullLoadResponse,
@@ -44,7 +44,7 @@ TASK_CLEANER_INTERVAL_SECONDS = float(
 REEMBED_INTERVAL_SECONDS = float(
     os.environ.get(
         "REEMBED_INTERVAL_SECONDS",
-        60,  # 1 minute
+        60 * 60,  # 1 hour
     )
 )
 

--- a/microservices/ingestservice/src/main.py
+++ b/microservices/ingestservice/src/main.py
@@ -81,7 +81,7 @@ def ingest_item(
         raise HTTPException(status_code=422, detail=str(exc))
 
     upsert_response = search_service_client.create_single_document(
-        document.model_dump()
+        document.id, document.model_dump()
     )
 
     if not document.embedText:

--- a/microservices/ingestservice/src/maintenance.py
+++ b/microservices/ingestservice/src/maintenance.py
@@ -15,6 +15,7 @@ async def reembedding_background_task(
 ):
     while True:
         await asyncio.sleep(interval_seconds)
+        logger.info("Running re-embedding task")
         try:
             await embed_partially_created_records(search_service_client, config)
         except Exception:
@@ -95,5 +96,6 @@ def build_query(models: list[str]) -> dict:
 
 async def task_cleaner(interval_seconds: float):
     while True:
+        logger.info("Cleaning up tasks")
         TaskStatus.clear()
         await asyncio.sleep(interval_seconds)

--- a/microservices/ingestservice/src/maintenance.py
+++ b/microservices/ingestservice/src/maintenance.py
@@ -1,0 +1,82 @@
+import asyncio
+import logging
+
+import httpx
+from envyaml import EnvYAML
+from src.clients import SearchServiceClient
+
+logger = logging.getLogger(__name__)
+
+
+async def reembedding_background_task(
+    interval_seconds: float, search_service_client: SearchServiceClient, config: EnvYAML
+):
+    while True:
+        await asyncio.sleep(interval_seconds)
+        try:
+            await embed_partially_created_records(search_service_client, config)
+        except Exception:
+            logger.error("Error during re-embedding task", exc_info=True)
+
+
+async def embed_partially_created_records(
+    search_service_client: SearchServiceClient, config: EnvYAML
+):
+    models = await get_models_info(config)
+
+    records = await get_partially_created_records(search_service_client, models)
+
+    for record in records:
+        models_for_embedding = [model for model in models if model in records]
+
+        async with httpx.AsyncClient() as client:
+            await client.post(
+                f"{config['base_url_embedding']}/add-embedding-to-doc",
+                json={
+                    "id": record["id"],
+                    "embedText": record["embedText"],
+                    "models": models_for_embedding,
+                },
+            )
+
+
+async def get_models_info(config: EnvYAML) -> list[str]:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"{config['base_url_embedding']}/models")
+
+    response.raise_for_status()
+
+    models = response.json()
+    if not models:
+        raise Exception("No models found in embedding service.")
+
+    return models
+
+
+async def get_partially_created_records(
+    search_service_client: SearchServiceClient, models=list[str]
+) -> list[dict]:
+    response = await asyncio.to_thread(search_service_client.query, build_query(models))
+    response.raise_for_status()
+
+    hits = response.get("hits", {}).get("hits", [])
+    if not hits:
+        raise Exception("No partially created records found.")
+
+    return [hit["_source"] for hit in hits]
+
+
+def build_query(models: list[str]) -> dict:
+    query = {
+        "_source": {"includes": ["id", "embedText", *models]},
+        "query": {
+            "bool": {
+                "should": [
+                    {"bool": {"must_not": [{"exists": {"field": model}}]}}
+                    for model in models
+                ]
+            }
+        },
+    }
+    logger.debug("Maintenance query: %s", query)
+    return query

--- a/microservices/ingestservice/src/maintenance.py
+++ b/microservices/ingestservice/src/maintenance.py
@@ -5,6 +5,7 @@ from typing import Any
 import httpx
 from envyaml import EnvYAML
 from src.clients import SearchServiceClient
+from src.task_status import TaskStatus
 
 logger = logging.getLogger(__name__)
 
@@ -90,3 +91,9 @@ def build_query(models: list[str]) -> dict:
     }
     logger.debug("Maintenance query: %s", query)
     return query
+
+
+async def task_cleaner(interval_seconds: float):
+    while True:
+        TaskStatus.clear()
+        await asyncio.sleep(interval_seconds)

--- a/microservices/ingestservice/tests/test_app.py
+++ b/microservices/ingestservice/tests/test_app.py
@@ -126,7 +126,7 @@ def test_upsert_event__with_available_correct_document__no_embedding_in_oss(
         },
     )
     httpx_mock.add_response(
-        url=config["base_url_search"] + "/document/test?fields=embedTextHash",
+        url=config["base_url_search"] + "/documents/test?fields=embedTextHash",
         method="GET",
         json={
             "took": 1,
@@ -178,7 +178,8 @@ def test_upsert_event__with_available_correct_document__no_embedding_in_oss(
     request = requests[1]
     assert request.method == "GET"
     assert (
-        request.url == config["base_url_search"] + "/document/test?fields=embedTextHash"
+        request.url
+        == config["base_url_search"] + "/documents/test?fields=embedTextHash"
     )
     assert request.headers["x-api-key"] == "test-key"
 
@@ -192,7 +193,7 @@ def test_upsert_event__with_available_correct_document__no_embedding_in_oss(
     # Request to the search service for upsert
     request = requests[0]
     assert request.method == "POST"
-    assert request.url == config["base_url_search"] + "/create-single-document"
+    assert request.url == config["base_url_search"] + "/documents/test"
     assert request.headers["x-api-key"] == "test-key"
     assert (
         request.content
@@ -256,7 +257,7 @@ def test_upsert_event__with_available_correct_document__no_matching_hash(
         },
     )
     httpx_mock.add_response(
-        url=config["base_url_search"] + "/document/test?fields=embedTextHash",
+        url=config["base_url_search"] + "/documents/test?fields=embedTextHash",
         method="GET",
         json={
             "took": 1,
@@ -311,7 +312,8 @@ def test_upsert_event__with_available_correct_document__no_matching_hash(
     request = requests[1]
     assert request.method == "GET"
     assert (
-        request.url == config["base_url_search"] + "/document/test?fields=embedTextHash"
+        request.url
+        == config["base_url_search"] + "/documents/test?fields=embedTextHash"
     )
     assert request.headers["x-api-key"] == "test-key"
 
@@ -325,7 +327,7 @@ def test_upsert_event__with_available_correct_document__no_matching_hash(
     # Request to the search service for upsert
     request = requests[0]
     assert request.method == "POST"
-    assert request.url == config["base_url_search"] + "/create-single-document"
+    assert request.url == config["base_url_search"] + "/documents/test"
     assert request.headers["x-api-key"] == "test-key"
     assert (
         request.content
@@ -389,7 +391,7 @@ def test_upsert_event__with_available_correct_document__matching_hash(
         },
     )
     httpx_mock.add_response(
-        url=config["base_url_search"] + "/document/test?fields=embedTextHash",
+        url=config["base_url_search"] + "/documents/test?fields=embedTextHash",
         method="GET",
         json={
             "took": 1,
@@ -444,14 +446,15 @@ def test_upsert_event__with_available_correct_document__matching_hash(
     request = requests[1]
     assert request.method == "GET"
     assert (
-        request.url == config["base_url_search"] + "/document/test?fields=embedTextHash"
+        request.url
+        == config["base_url_search"] + "/documents/test?fields=embedTextHash"
     )
     assert request.headers["x-api-key"] == "test-key"
 
     # Request to the search service for upsert
     request = requests[0]
     assert request.method == "POST"
-    assert request.url == config["base_url_search"] + "/create-single-document"
+    assert request.url == config["base_url_search"] + "/documents/test"
     assert request.headers["x-api-key"] == "test-key"
     assert (
         request.content
@@ -604,7 +607,7 @@ def test_delete_event_with_available_correct_document(
     # Request to the search service
     request = requests[0]
     assert request.method == "DELETE"
-    assert request.url == config["base_url_search"] + "/delete-data?document_id=valid"
+    assert request.url == config["base_url_search"] + "/documents/valid"
     assert request.headers["x-api-key"] == "test-key"
 
 
@@ -615,7 +618,7 @@ def test_bulk_ingest__with_validation_error(
         url=config["base_url_embedding"] + "/embedding", json={"model": [1, 2]}
     )
     httpx_mock.add_response(
-        url=config["base_url_search"] + "/create-multiple-documents",
+        url=config["base_url_search"] + "/documents",
         json={"status": "ok"},
         status_code=200,
     )
@@ -643,7 +646,7 @@ def test_bulk_ingest__with_validation_error(
 
     request = requests[1]
     assert request.method == "POST"
-    assert request.url == config["base_url_search"] + "/create-multiple-documents"
+    assert request.url == config["base_url_search"] + "/documents"
     assert request.headers["x-api-key"] == "test-key"
     assert (
         request.content

--- a/microservices/searchservice/src/main.py
+++ b/microservices/searchservice/src/main.py
@@ -1,5 +1,5 @@
 import os
-from typing import Annotated
+from typing import Annotated, Any
 
 from envyaml import EnvYAML
 from fastapi import APIRouter, FastAPI, Depends, Query
@@ -35,8 +35,7 @@ def create_document(
 ):
     # Add data to index
     print(data, type(data))
-    response = oss_accessor.create_oss_doc(document_id, data)
-    return response
+    return oss_accessor.create_oss_doc(document_id, data)
 
 
 @router.post("/documents")
@@ -45,16 +44,14 @@ def bulk_create_document(
     oss_accessor: OssAccessor = Depends(get_oss_accessor),
 ):
     # add data to index
-    response = oss_accessor.bulk_ingest(data)
-    return response
+    return oss_accessor.bulk_ingest(data)
 
 
 @router.delete("/documents/{document_id}")
 def delete_document(
     document_id: str, oss_accessor: OssAccessor = Depends(get_oss_accessor)
 ):
-    response = oss_accessor.delete_oss_doc(document_id)
-    return response
+    return oss_accessor.delete_oss_doc(document_id)
 
 
 @router.get("/documents/{document_id}")
@@ -64,19 +61,15 @@ def get_document(
     oss_accessor: OssAccessor = Depends(get_oss_accessor),
 ):
     _fields = fields.split(",") if fields else []
-    response = oss_accessor.get_oss_doc(document_id, _fields)
-    return response
+    return oss_accessor.get_oss_doc(document_id, _fields)
 
 
-@router.get("/documents")
-def get_document_without_embedding(
-    document_id: str,
-    fields: Annotated[str | None, Query()] = None,
+@router.post("/query")
+def get_document_with_query(
+    query: dict[str, Any],
     oss_accessor: OssAccessor = Depends(get_oss_accessor),
 ):
-    _fields = fields.split(",") if fields else []
-    response = oss_accessor.get_oss_doc(document_id, _fields)
-    return response
+    return oss_accessor.get_oss_docs(query)
 
 
 # TODO: search query for nearest neighbors

--- a/microservices/searchservice/src/main.py
+++ b/microservices/searchservice/src/main.py
@@ -27,17 +27,19 @@ def health_check():
     return {"status": "OK"}
 
 
-@router.post("/create-single-document")
+@router.post("/documents/{document_id}")
 def create_document(
-    data: CreateDocumentRequest, oss_accessor: OssAccessor = Depends(get_oss_accessor)
+    document_id: str,
+    data: CreateDocumentRequest,
+    oss_accessor: OssAccessor = Depends(get_oss_accessor),
 ):
     # Add data to index
     print(data, type(data))
-    response = oss_accessor.create_oss_doc(data)
+    response = oss_accessor.create_oss_doc(document_id, data)
     return response
 
 
-@router.post("/create-multiple-documents")
+@router.post("/documents")
 def bulk_create_document(
     data: dict[str, CreateDocumentRequest],
     oss_accessor: OssAccessor = Depends(get_oss_accessor),
@@ -47,7 +49,7 @@ def bulk_create_document(
     return response
 
 
-@router.delete("/delete-data")
+@router.delete("/documents/{document_id}")
 def delete_document(
     document_id: str, oss_accessor: OssAccessor = Depends(get_oss_accessor)
 ):
@@ -55,8 +57,19 @@ def delete_document(
     return response
 
 
-@router.get("/document/{document_id}")
+@router.get("/documents/{document_id}")
 def get_document(
+    document_id: str,
+    fields: Annotated[str | None, Query()] = None,
+    oss_accessor: OssAccessor = Depends(get_oss_accessor),
+):
+    _fields = fields.split(",") if fields else []
+    response = oss_accessor.get_oss_doc(document_id, _fields)
+    return response
+
+
+@router.get("/documents")
+def get_document_without_embedding(
     document_id: str,
     fields: Annotated[str | None, Query()] = None,
     oss_accessor: OssAccessor = Depends(get_oss_accessor),

--- a/microservices/searchservice/src/oss_accessor.py
+++ b/microservices/searchservice/src/oss_accessor.py
@@ -36,13 +36,13 @@ class OssAccessor:
 
         return cls(index, client)
 
-    def create_oss_doc(self, data: CreateDocumentRequest):
+    def create_oss_doc(self, id: str, data: CreateDocumentRequest):
         # add document to index
         print(data, type(data))
         response = self.oss_client.update(
             index=self.target_idx_name,
             body={"doc": data.model_dump(), "doc_as_upsert": True},
-            id=data.id,
+            id=id,
             refresh=True,
         )
 

--- a/microservices/searchservice/src/oss_accessor.py
+++ b/microservices/searchservice/src/oss_accessor.py
@@ -1,4 +1,11 @@
-from opensearchpy import OpenSearch, RequestsHttpConnection, helpers, NotFoundError
+from fastapi import HTTPException
+from opensearchpy import (
+    OpenSearch,
+    RequestsHttpConnection,
+    helpers,
+    NotFoundError,
+    RequestError,
+)
 from typing import Any, Iterator, Self
 import logging
 import json
@@ -93,3 +100,11 @@ class OssAccessor:
                 "_source": {"includes": fields},
             },
         )
+
+    def get_oss_docs(self, query: dict[str, str]) -> dict:
+        try:
+            return self.oss_client.search(index=self.target_idx_name, body=query)
+        except RequestError as e:
+            raise HTTPException(
+                detail=f"Invalid query: {e.info}", status_code=400
+            ) from e

--- a/microservices/searchservice/tests/test_api.py
+++ b/microservices/searchservice/tests/test_api.py
@@ -1,5 +1,5 @@
 import pytest
-from opensearchpy import OpenSearch
+from opensearchpy import OpenSearch, RequestError
 from src.oss_accessor import OssAccessor
 from fastapi.testclient import TestClient
 
@@ -78,6 +78,32 @@ def mock_oss(mocker):
     }
 
     def _search(*a, **kw):
+        if kw["body"]["query"].get("bool"):
+            if kw["body"]["query"]["bool"]["must_not"][0]["exists"]["field"] == [
+                "test"
+            ]:
+                raise RequestError(400, "test", "test")
+            return {
+                "took": 1,
+                "timed_out": False,
+                "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
+                "hits": {
+                    "total": {"value": 1, "relation": "eq"},
+                    "max_score": 1,
+                    "hits": [
+                        {
+                            "_index": kw["index"],
+                            "_id": "no_embedding",
+                            "_score": 0,
+                            "_source": {
+                                "id": "no_embedding",
+                                "test_field": "test_value",
+                            },
+                        }
+                    ],
+                },
+            }
+
         data = {
             "id": kw["body"]["query"]["ids"]["values"][0],
             "embedTextHash": "IAmAHash",
@@ -288,3 +314,62 @@ def test_get_document__valid_request_with_fields(test_client, mock_oss):
             ],
         },
     }
+
+
+def test_documents_no_embedding__valid_request(test_client, mock_oss):
+    response = test_client.post(
+        "query",
+        json={
+            "_source": {"includes": ["id"]},
+            "query": {"bool": {"must_not": [{"exists": {"field": "test"}}]}},
+        },
+    )
+    assert response.status_code == 200
+    assert mock_oss.search.call_count == 1
+    assert mock_oss.search.call_args[1] == {
+        "index": "test",
+        "body": {
+            "_source": {"includes": ["id"]},
+            "query": {"bool": {"must_not": [{"exists": {"field": "test"}}]}},
+        },
+    }
+    assert response.json() == {
+        "took": 1,
+        "timed_out": False,
+        "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
+        "hits": {
+            "total": {"value": 1, "relation": "eq"},
+            "max_score": 1,
+            "hits": [
+                {
+                    "_index": "test",
+                    "_id": "no_embedding",
+                    "_score": 0,
+                    "_source": {
+                        "id": "no_embedding",
+                        "test_field": "test_value",
+                    },
+                }
+            ],
+        },
+    }
+
+
+def test_documents_no_embedding__invalid_request(test_client, mock_oss):
+    response = test_client.post(
+        "query",
+        json={
+            "_source": {"includes": ["id"]},
+            "query": {"bool": {"must_not": [{"exists": {"field": ["test"]}}]}},
+        },
+    )
+    assert response.status_code == 400
+    assert mock_oss.search.call_count == 1
+    assert mock_oss.search.call_args[1] == {
+        "index": "test",
+        "body": {
+            "_source": {"includes": ["id"]},
+            "query": {"bool": {"must_not": [{"exists": {"field": ["test"]}}]}},
+        },
+    }
+    assert response.json() == {"detail": "Invalid query: test"}

--- a/microservices/searchservice/tests/test_api.py
+++ b/microservices/searchservice/tests/test_api.py
@@ -138,9 +138,7 @@ def test_health_check(test_client):
 
 
 def test_create_single_document__valid_request(test_client, mock_oss):
-    response = test_client.post(
-        "/create-single-document", json={"id": "test", "text": "test"}
-    )
+    response = test_client.post("/documents/test", json={"id": "test", "text": "test"})
     assert response.status_code == 200
 
     assert mock_oss.update.call_count == 1
@@ -163,7 +161,7 @@ def test_create_single_document__valid_request(test_client, mock_oss):
 
 
 def test_create_single_document__malformed_request(test_client):
-    response = test_client.post("/create-single-document", json={"text": "test"})
+    response = test_client.post("/documents/test", json={"text": "test"})
     assert response.status_code == 422
     assert response.json() == {
         "detail": [
@@ -179,7 +177,7 @@ def test_create_single_document__malformed_request(test_client):
 
 def test_create_multiple_documents__valid_request(test_client, mock_oss, mocker):
     response = test_client.post(
-        "/create-multiple-documents",
+        "/documents",
         json={"test1": {"id": "test1"}, "test2": {"id": "test2"}},
     )
     assert response.status_code == 200
@@ -193,7 +191,7 @@ def test_create_multiple_documents__valid_request(test_client, mock_oss, mocker)
 
 
 def test_create_multiple_documents__malformed_request(test_client):
-    response = test_client.post("/create-multiple-documents", json={"id": "test"})
+    response = test_client.post("/documents", json={"id": "test"})
     assert response.status_code == 422
     assert response.json() == {
         "detail": [
@@ -208,7 +206,7 @@ def test_create_multiple_documents__malformed_request(test_client):
 
 
 def test_delete_document__valid_request(test_client, mock_oss):
-    response = test_client.delete("/delete-data", params={"document_id": "test"})
+    response = test_client.delete("/documents/test")
     assert response.status_code == 200
 
     assert mock_oss.delete.call_count == 1
@@ -228,23 +226,8 @@ def test_delete_document__valid_request(test_client, mock_oss):
     }
 
 
-def test_delete_document__malformed_request(test_client):
-    response = test_client.delete("/delete-data", params={"id": "test"})
-    assert response.status_code == 422
-    assert response.json() == {
-        "detail": [
-            {
-                "input": None,
-                "loc": ["query", "document_id"],
-                "msg": "Field required",
-                "type": "missing",
-            }
-        ]
-    }
-
-
 def test_get_document__valid_request_with_no_fields(test_client, mock_oss):
-    response = test_client.get("/document/test")
+    response = test_client.get("/documents/test")
     assert response.status_code == 200
     assert mock_oss.search.call_count == 1
     assert mock_oss.search.call_args[1] == {
@@ -275,7 +258,7 @@ def test_get_document__valid_request_with_no_fields(test_client, mock_oss):
 
 
 def test_get_document__valid_request_with_fields(test_client, mock_oss):
-    response = test_client.get("/document/test?fields=embedTextHash%2Cid")
+    response = test_client.get("/documents/test?fields=embedTextHash%2Cid")
     assert response.status_code == 200
     assert mock_oss.search.call_count == 1
     assert mock_oss.search.call_args[1] == {


### PR DESCRIPTION
Ich habe den Background Task jetzt in den Ingest gebaut, das es aus meiner Sicht der Ingest Service der Driver für jegliche Ingestion sein sollte, damit auch jegliche Business Logic an einer Stelle gebündelt ist und wir den Embedding und den Search Service als reine REST Schnittstellen ohne Logik belassen.

Außerdem habe ich den ein paar refactorings mit eingebracht.