### PR TITLE
SNTWREC-424-425 enable returning of embedded part of the text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ junit/
 
 # VS Code
 *DS_Store
+
+# Models for local testing of embedding service
+microservices/embeddingservice/test_dl

--- a/microservices/embeddingservice/dto/embed_data.py
+++ b/microservices/embeddingservice/dto/embed_data.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 class EmbeddingRequest(BaseModel):
     embedText: str
     models: list[str] | None = None
-    return_embed_text: bool
+    return_embed_text = False
 
 
 class AddEmbeddingToDocRequest(BaseModel):

--- a/microservices/embeddingservice/dto/embed_data.py
+++ b/microservices/embeddingservice/dto/embed_data.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 class EmbeddingRequest(BaseModel):
     embedText: str
     models: list[str] | None = None
+    return_embed_text: bool
 
 
 class AddEmbeddingToDocRequest(BaseModel):

--- a/microservices/embeddingservice/dto/embed_data.py
+++ b/microservices/embeddingservice/dto/embed_data.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 class EmbeddingRequest(BaseModel):
     embedText: str
     models: list[str] | None = None
-    return_embed_text = False
+    return_embed_text: bool = False
 
 
 class AddEmbeddingToDocRequest(BaseModel):

--- a/microservices/embeddingservice/src/embed_text.py
+++ b/microservices/embeddingservice/src/embed_text.py
@@ -131,7 +131,7 @@ class EmbedText:
             self.models_max_length[model_config["model_name"]] = self.models[model_config["model_name"]].tokenizer.model_max_length
 
 
-    def embed_text(self, embed_text: str, return_embed_text: bool, models_to_use: list[str] | None):
+    def embed_text(self, embed_text: str, models_to_use: list[str] | None, return_embed_text = False):
         response: dict[str, str | list[float]] = {
             "embedTextHash": sha256(embed_text.encode("utf-8")).hexdigest()
         }

--- a/microservices/embeddingservice/src/embed_text.py
+++ b/microservices/embeddingservice/src/embed_text.py
@@ -12,6 +12,7 @@ from google.cloud import storage
 from google.oauth2 import service_account
 from numpy import ndarray
 from sentence_transformers import SentenceTransformer
+import re
 
 from src.constants import (
     MODELS_KEY,
@@ -53,7 +54,8 @@ def cut_to_full_sentence(
     """
     Cut off the text at the last full sentence.
     """
-    return text[:text.rfind(".")+1].strip() if text.rfind(".") != -1 else text.strip()
+    match = re.search(r'[\.!?](?!.*[\.!?])', text)
+    return text[:match.end()].strip() if match else text.strip()
 
 class EmbedText:
     def __init__(self, config):

--- a/microservices/embeddingservice/src/main.py
+++ b/microservices/embeddingservice/src/main.py
@@ -38,7 +38,7 @@ def health_check():
 
 @router.post("/embedding")
 def get_embedding(data: EmbeddingRequest):
-    return text_embedder.embed_text(data.embedText, data.models)
+    return text_embedder.embed_text(data.embedText, data.return_embed_text, data.models)
 
 
 @router.post("/add-embedding-to-doc")

--- a/microservices/embeddingservice/src/main.py
+++ b/microservices/embeddingservice/src/main.py
@@ -38,7 +38,7 @@ def health_check():
 
 @router.post("/embedding")
 def get_embedding(data: EmbeddingRequest):
-    return text_embedder.embed_text(data.embedText, data.return_embed_text, data.models)
+    return text_embedder.embed_text(data.embedText, data.models, data.return_embed_text)
 
 
 @router.post("/add-embedding-to-doc")

--- a/microservices/embeddingservice/tests/test_api.py
+++ b/microservices/embeddingservice/tests/test_api.py
@@ -121,6 +121,64 @@ def test_embedding__with_models(test_client: TestClient):
     assert response_json["unknown-model"] == "unknown model!"
 
 
+def test_embedding__with_text_returned(test_client: TestClient):
+    response = test_client.post(
+        "/embedding",
+        json={
+            "embedText": "This is a test.",
+            "models": [],
+            "return_embed_text": True,
+        },
+    )
+
+    response_json = response.json()
+    assert response.status_code == 200
+    assert (
+        response_json["embedTextHash"]
+        == "a8a2f6ebe286697c527eb35a58b5539532e9b3ae3b64d4eb0a46fb657b41562c"
+    )
+    assert all(
+        isinstance(response_json[key], dict) 
+        for key in response_json.keys() if key != "embedTextHash"
+    )
+    assert all(
+        isinstance(response_json[key]["embedded_text"], str) and len(response_json[key]["embedded_text"]) > 0
+        for key in response_json.keys() if key != "embedTextHash"
+    )
+    assert all(
+        isinstance(elem, float) 
+        for key in response_json.keys() if key != "embedTextHash"
+        for elem in response_json[key]["embedding"]
+    )
+
+
+def test_embedding__no_text_returned(test_client: TestClient):
+    response = test_client.post(
+        "/embedding",
+        json={
+            "embedText": "This is a test.",
+            "models": [],
+            "return_embed_text": False,
+        },
+    )
+
+    response_json = response.json()
+    assert response.status_code == 200
+    assert (
+        response_json["embedTextHash"]
+        == "a8a2f6ebe286697c527eb35a58b5539532e9b3ae3b64d4eb0a46fb657b41562c"
+    )
+    assert all(
+        isinstance(response_json[key], list)
+        for key in response_json.keys() if key != "embedTextHash"
+    )
+    assert all(
+    isinstance(elem, float) 
+    for key in response_json.keys() if key != "embedTextHash"
+    for elem in response_json[key]
+    )
+    
+    
 def test_add_embedding_to_document__malformed_request(test_client: TestClient):
     response = test_client.post(
         "/add-embedding-to-doc",


### PR DESCRIPTION
🟢Added a new argument **return_embed_text** to the POST-Method Embedding that enables returning the part of that input text that was actually embedded by a specific LLM

🟢Added a new attribute **models_max_length** to the **EmbedText** class that stores the supported maximal length of the input text for each available LLM (extracted from the attributes of the respective tokenizers)

🟢Added **cut_to_full_sentence** function to ensure that the embedded text is "rounded" to the end of the last sentence (searching for the last full stop).

🟢In case **return_embed_text** is set to true the returned response[model] is not a list, but rather a dictionary with two key-value pairs:
      💡"embedded_text" : part of that input text that was actually embedded [str]
      💡 "embedding" : the actual embedding [list]