### PR TITLE
SNTWREC-350 add new Refinement Widget Manager for new Tenant M14

### DIFF
--- a/src/controller/RefinementWidgetManger/M14RefinementWidgetRequestManger.py
+++ b/src/controller/RefinementWidgetManger/M14RefinementWidgetRequestManger.py
@@ -1,0 +1,16 @@
+from controller.RefinementWidgetManger.RefinementWidgetStatefulManger import RefinementWidgetStatefulManger
+
+class M14RefinementWidgetRequestManger(RefinementWidgetStatefulManger):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.weights = {
+            "Semantic": {"semanticWeight": 0.35, "timeWeight": 0.2},
+            "Diverse": {"diversityWeight": 0.7, "timeWeight": 0.2},
+            "Temporal": {"timeWeight": 0.5}
+        }
+
+    def map_refinement_direction(self, direction):
+        # Specific logic for WDR_PA
+        if direction == "more similar":
+            return "more similar embeddings"
+        return direction

--- a/src/controller/RefinementWidgetManger/M14RefinementWidgetRequestManger.py
+++ b/src/controller/RefinementWidgetManger/M14RefinementWidgetRequestManger.py
@@ -1,6 +1,6 @@
 from controller.RefinementWidgetManger.RefinementWidgetStatefulManger import RefinementWidgetStatefulManger
 
-class BrRefinementWidgetRequestManger(RefinementWidgetStatefulManger):
+class M14RefinementWidgetRequestManger(RefinementWidgetStatefulManger):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.weights = {

--- a/src/controller/RefinementWidgetManger/M14RefinementWidgetRequestManger.py
+++ b/src/controller/RefinementWidgetManger/M14RefinementWidgetRequestManger.py
@@ -4,9 +4,9 @@ class M14RefinementWidgetRequestManger(RefinementWidgetStatefulManger):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.weights = {
-            "Semantic": {"semanticWeight": 0.35, "tagWeight": 0.35, "timeWeight": 0.2, "localTrendWeight": 0.1},
-            "Diverse": {"diversityWeight": 0.7, "timeWeight": 0.2, "localTrendWeight": 0.1},
-            "Temporal": {"timeWeight": 0.5, "localTrendWeight": 0.5}
+            "Semantic": {"semanticWeight": 0.35, "timeWeight": 0.2},
+            "Diverse": {"diversityWeight": 0.7, "timeWeight": 0.2},
+            "Temporal": {"timeWeight": 0.5}
         }
 
     def map_refinement_direction(self, direction):

--- a/src/controller/RefinementWidgetManger/M14RefinementWidgetRequestManger.py
+++ b/src/controller/RefinementWidgetManger/M14RefinementWidgetRequestManger.py
@@ -1,16 +1,13 @@
 from controller.RefinementWidgetManger.RefinementWidgetStatefulManger import RefinementWidgetStatefulManger
 
-class M14RefinementWidgetRequestManger(RefinementWidgetStatefulManger):
+class BrRefinementWidgetRequestManger(RefinementWidgetStatefulManger):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.weights = {
-            "Semantic": {"semanticWeight": 0.35, "timeWeight": 0.2},
-            "Diverse": {"diversityWeight": 0.7, "timeWeight": 0.2},
-            "Temporal": {"timeWeight": 0.5}
+            "Semantic": {"semanticWeight": 0.35, "tagWeight": 0.35, "timeWeight": 0.2, "localTrendWeight": 0.1},
+            "Diverse": {"diversityWeight": 0.7, "timeWeight": 0.2, "localTrendWeight": 0.1},
+            "Temporal": {"timeWeight": 0.5, "localTrendWeight": 0.5}
         }
 
     def map_refinement_direction(self, direction):
-        # Specific logic for WDR_PA
-        if direction == "more similar":
-            return "more similar embeddings"
         return direction

--- a/src/controller/reco_controller.py
+++ b/src/controller/reco_controller.py
@@ -1,5 +1,6 @@
 from controller.RefinementWidgetManger.BrRefinementWidgetRequestManger import BrRefinementWidgetRequestManger
 from controller.RefinementWidgetManger.WdrRefinementWidgetRequestManger import WdrRefinementWidgetRequestManger
+from controller.RefinementWidgetManger.M14RefinementWidgetRequestManger import M14RefinementWidgetRequestManger
 from controller.RefinementWidgetManger.NoRefinementWidgetRequestManger import NoRefinementWidgetRequestManger
 from model.rest.nn_seeker_paservice_clients import NnSeekerPaServiceClients
 import logging
@@ -36,8 +37,11 @@ class RecommendationController():
         self.config = config
         self.current_client = current_client
         # Choose the appropriate builder based on the current client
-        self.refinement_widget = {"br": BrRefinementWidgetRequestManger(),
-            "wdr": WdrRefinementWidgetRequestManger()}.get(current_client,NoRefinementWidgetRequestManger())
+        self.refinement_widget = {
+            "br": BrRefinementWidgetRequestManger(),
+            "wdr": WdrRefinementWidgetRequestManger(),
+            "m14": M14RefinementWidgetRequestManger(),
+        }.get(current_client,NoRefinementWidgetRequestManger())
 
         self.item_accessor = BaseDataAccessorOpenSearch(config)
         if constants.MODEL_CONFIG_U2C in config:


### PR DESCRIPTION
To get a new Tenant (M14 or Unified Sophora) to work in Reco Explorer that also uses the Refinement Widget we need a Refinement Widget Manager. I created a new one for the new tenant but I am not sure what weights or direction to set. The Ticket only mentions that M14 should have a Refinement Widget like WDR or BR but these have different values set by their Managers. 
For now I decided to clone the WDR Manager, if thats not the correct setup of that widget, please let me know. 