### PR TITLE
SNTWREC-350 change dockerfile to install packages for native builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,25 @@
 FROM public.ecr.aws/docker/library/python:3.10-slim-bullseye
 
 # Allow statements and log messages to immediately appear in the Knative logs
-ENV PYTHONUNBUFFERED True
+ENV PYTHONUNBUFFERED=True
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
 # Copy local code to the container image.
-ENV APP_HOME /app
+ENV APP_HOME=/app
 WORKDIR $APP_HOME
 COPY src/RecoExplorer.py RecoExplorer.py
 
+# Install packages for native builds, not part of the baseimage
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential gcc g++ python3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Upgrade Pip-Tooling
+RUN pip install --upgrade pip setuptools wheel
+
 # Install production dependencies.
 COPY requirements.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --default-timeout=120 --retries=5 -r requirements.txt
 
 #modules
 COPY assets assets
@@ -28,9 +37,8 @@ COPY src/view view
 COPY src/dto dto
 COPY src/constants.py constants.py
 
-
 # Run the web service on container startup.
 EXPOSE 80
 
 # go
-CMD panel serve RecoExplorer.py --address 0.0.0.0 --port 80 --allow-websocket-origin="*" --log-level info
+CMD ["panel", "serve", "RecoExplorer.py", "--address", "0.0.0.0", "--port", "80", "--allow-websocket-origin=*", "--log-level", "info"]


### PR DESCRIPTION
In the requirements pyfarmhash was added shortly. This only works as log as the dase image contains necessary dependencies (gcc) which the one given in the dockerfile does not. So locally you can run pip install requirements.txt but the build pipeline crashes because its using another Image where depenedcies are missing. 
Here I added these dependencies to the dockerfile, so pip can install the requirements again and the build pipeline should run. 